### PR TITLE
libagl: Fix buffer read overrun in eglCreatePbufferSurface

### DIFF
--- a/opengl/libagl/egl.cpp
+++ b/opengl/libagl/egl.cpp
@@ -1346,7 +1346,7 @@ static EGLSurface createPbufferSurface(EGLDisplay dpy, EGLConfig config,
 
     int32_t w = 0;
     int32_t h = 0;
-    while (attrib_list[0]) {
+    while (attrib_list[0] != EGL_NONE) {
         if (attrib_list[0] == EGL_WIDTH)  w = attrib_list[1];
         if (attrib_list[0] == EGL_HEIGHT) h = attrib_list[1];
         attrib_list+=2;


### PR DESCRIPTION
The code was assuming that EGL_NONE==0, which isn't true.

Bug: 23403170
Change-Id: Ic1eccdef086b4d610bd78dbb6b2ae883c91dc322